### PR TITLE
fix: add more descriptive text for aria-label

### DIFF
--- a/src/components/Button/ScrollTop.js
+++ b/src/components/Button/ScrollTop.js
@@ -49,7 +49,7 @@ export default class ScrollTop extends React.Component {
 
     return (
       <div
-        aria-label="Scroll to top"
+        aria-label="Scroll to the top of the page"
         tabIndex={scrollToTopClass ? 0 : -1}
         className={`transition-slow fixed cursor-pointer opacity-0 z-10 ${scrollToTopClass}`}
         style={{


### PR DESCRIPTION
The attribute aria-label="Scroll to top" suggests that it represents a button or element that allows users to scroll back to the top of a page.

Lack of descriptive text: The `aria-label` attribute should provide a concise and meaningful description of the button's purpose. However the value "Scroll to top" is not informative enough. Screen readers, which are assistive technologies used by individuals with visual impairments, rely on these labels to convey information to the user. 

Solution:
Provide a more descriptive label, such as "Scroll to top of the page," would be more helpful.

Please review the changes and let us know if any further modifications or adjustments are required. I believe these updates will significantly improve the accessibility of the button for users with visual impairments.

Thank you for your attention to this matter.

@ttkapostol @ErriGarcia @NataliaBlanco